### PR TITLE
fix parse object to add wms layer

### DIFF
--- a/src/MapView.js
+++ b/src/MapView.js
@@ -99,6 +99,16 @@ export default class MapView extends Component {
           }
           return object;
         }
+        if (Array.isArray(data)) {
+          return data.map(parse);
+        }
+        if (typeof(data) === 'object') {
+          let object = {};
+          for (i in data) {
+            object[i] = parse(data[i]);
+          }
+          return object;
+        }
 
         return data;
       }


### PR DESCRIPTION
test with 
`call("Layers.add", [{"args":["roadnet2:Road_FGDS",{"weight":10,"bound":{"minLat":10,"minLon":100,"maxLon":105,"maxLat":20},"refresh":180,"type":{"$static":"LayerType","name":"WMS"},"url":"https://apix.longdo.com/vector/test-tile.php","opacity":0.5,"zoomRange":{"max":9,"min":1}}],"$object":"Layer","$id":6}])`